### PR TITLE
2.0.5.1

### DIFF
--- a/woocommerce-qenta-checkout-seamless/classes/class-qenta-config.php
+++ b/woocommerce-qenta-checkout-seamless/classes/class-qenta-config.php
@@ -31,7 +31,7 @@
  */
 
 define( 'WOOCOMMERCE_GATEWAY_QMORE_NAME', 'QentaCheckoutSeamless' );
-define( 'WOOCOMMERCE_GATEWAY_QMORE_VERSION', '2.0.5' );
+define( 'WOOCOMMERCE_GATEWAY_QMORE_VERSION', '2.0.5.1' );
 
 /**
  * Config class

--- a/woocommerce-qenta-checkout-seamless/classes/includes/form_fields.php
+++ b/woocommerce-qenta-checkout-seamless/classes/includes/form_fields.php
@@ -176,7 +176,7 @@ $fields = array(
 	'creditcardoptions'   => array(
 		'woo_wcs_saqacompliance'                         => array(
 			'type'        => 'switch',
-			'default'     => 0,
+			'default'     => 1,
 			'title'       => __( 'SAQ A compliance', 'woocommerce-qenta-checkout-seamless' ),
 			'description' => __( 'Selecting \'NO\', the stringent SAQ A-EP is applicable. Selecting \'YES\', Qenta Checkout Seamless is integrated with the \'PCI DSS SAQ A Compliance\' feature and SAQ A is applicable.',
 			                     'woocommerce-qenta-checkout-seamless' )

--- a/woocommerce-qenta-checkout-seamless/languages/woocommerce-qenta-checkout-seamless-de_DE.po
+++ b/woocommerce-qenta-checkout-seamless/languages/woocommerce-qenta-checkout-seamless-de_DE.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: QentaCheckoutSeamless 2.0.5\n"
+"Project-Id-Version: QentaCheckoutSeamless 2.0.5.1\n"
 "Report-Msgid-Bugs-To: https://github.com/qenta-cee/woocommerce-qcs/issues\n"
 "POT-Creation-Date: 2017-05-05 10:52+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/woocommerce-qenta-checkout-seamless/languages/woocommerce-qenta-checkout-seamless-en_US.po
+++ b/woocommerce-qenta-checkout-seamless/languages/woocommerce-qenta-checkout-seamless-en_US.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: QentaCheckoutSeamless 2.0.5\n"
+"Project-Id-Version: QentaCheckoutSeamless 2.0.5.1\n"
 "Report-Msgid-Bugs-To: https://github.com/qenta-cee/woocommerce-qcs\n"
 "POT-Creation-Date: 2017-05-05 10:52+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/woocommerce-qenta-checkout-seamless/readme.txt
+++ b/woocommerce-qenta-checkout-seamless/readme.txt
@@ -2,8 +2,8 @@
 Contributors:
 Tags: visa, mastercard, sofort, paypal, credit card, klarna, eps, giropay, sepa, ecommerce, checkout, payment
 Requires at least: 5.5.1
-Tested up to: 5.8.3
-Stable tag: 2.0.5
+Tested up to: 5.9
+Stable tag: 2.0.5.1
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/woocommerce-qenta-checkout-seamless/woocommerce-qenta-checkout-seamless.php
+++ b/woocommerce-qenta-checkout-seamless/woocommerce-qenta-checkout-seamless.php
@@ -3,9 +3,9 @@
  * Plugin Name: Qenta Checkout Seamless
  * Plugin URI: https://github.com/qenta-cee/woocommerce-qcs
  * Description: Qenta Checkout Seamless plugin for WooCommerce
- * Version: 2.0.5
+ * Version: 2.0.5.1
  * Author: Qenta Payment CEE GmbH
- * Author URI: https://www.qenta-cee.at/
+ * Author URI: https://www.qenta.com/
  * License: GPL2
  */
 


### PR DESCRIPTION
**Fixes**
- Fix issue with payment validation when consumer adds spaces after cardholder name

**Changes**
- Set SAQ A to default ON for new installations
- Remove preselection of Qenta Payment Method to avoid interference with 3rd party payment plugins
- Test with version 5.9 of WP
